### PR TITLE
Not to call self endpoint via HTTP.

### DIFF
--- a/src/java/net/unit8/job_streamer/control_bus/JobStreamerExecuteJob.java
+++ b/src/java/net/unit8/job_streamer/control_bus/JobStreamerExecuteJob.java
@@ -1,14 +1,15 @@
 package net.unit8.job_streamer.control_bus;
 
+import clojure.java.api.Clojure;
+import clojure.lang.*;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
-import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
+
+import net.unit8.job_streamer.control_bus.util.SystemUtil;
 
 /**
  * @author kawasima
@@ -19,31 +20,22 @@ public class JobStreamerExecuteJob implements Job {
     public void execute(JobExecutionContext context) throws JobExecutionException {
         JobDataMap data = context.getMergedJobDataMap();
         String jobName = data.getString("job-name");
-        String host = data.getString("host");
-        long port = data.getLong("port");
         String appName = data.getString("app-name");
-        String token = data.getString("token");
 
-        URLConnection conn;
-        try {
-            URL url = new URL("http://" + host + ":" + port
-                    + "/" + appName
-                    + "/job/" + jobName
-                    + "/executions");
+        Object system = SystemUtil.getSystem();
+        Object jobs = RT.get(system, Keyword.intern("jobs"));
 
-            conn = url.openConnection();
-            conn.setReadTimeout(5000);
-            conn.setConnectTimeout(1000);
-            ((HttpURLConnection) conn).setRequestMethod("POST");
-            ((HttpURLConnection) conn).setRequestProperty("Authorization", "Token " + token);
-            conn.connect();
-            int statusCode = ((HttpURLConnection) conn).getResponseCode();
-            if (statusCode != HttpURLConnection.HTTP_CREATED) {
-                throw new JobExecutionException("HttpRequest not success:" + statusCode);
-            }
-        } catch (IOException ex) {
-            throw new JobExecutionException(ex);
+        IFn executionsResource = Clojure.var("job-streamer.control-bus.component.jobs", "executions-resource");
+        IFn handler = (IFn) executionsResource.invoke(jobs, appName, jobName);
+        PersistentHashMap request = PersistentHashMap.create(
+                Keyword.intern("request-method"), Keyword.intern("post"),
+                Keyword.intern("identity"), PersistentHashMap.create(
+                    Keyword.intern("permissions"), PersistentHashSet.create(
+                        Keyword.intern("permission", "execute-job"))),
+                Keyword.intern("content-type"), "application/edn");
+        long statusCode = (long) RT.get(handler.invoke(request), Keyword.intern("status"));
+        if (statusCode != (long) HttpURLConnection.HTTP_CREATED) {
+            throw new JobExecutionException("HttpRequest not success:" + statusCode);
         }
-
     }
 }

--- a/src/java/net/unit8/job_streamer/control_bus/TimeKeeperJob.java
+++ b/src/java/net/unit8/job_streamer/control_bus/TimeKeeperJob.java
@@ -1,14 +1,15 @@
 package net.unit8.job_streamer.control_bus;
 
+import clojure.java.api.Clojure;
+import clojure.lang.*;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
-import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
+
+import net.unit8.job_streamer.control_bus.util.SystemUtil;
 
 /**
  * @author kawasima
@@ -22,32 +23,20 @@ public class TimeKeeperJob implements Job {
         Long executionId = data.getLong("execution-id");
         String command = data.getString("command");
 
-        String host = data.getString("host");
-        long port = data.getLong("port");
-        String token = data.getString("token");
+        Object system = SystemUtil.getSystem();
+        Object jobs = RT.get(system, Keyword.intern("jobs"));
 
-        URLConnection conn;
-        try {
-            URL url = new URL("http://" + host + ":" + port
-                    + "/" + appName
-                    + "/job/" + jobName
-                    + "/execution/" + executionId
-                    + "/" + command);
-
-            conn = url.openConnection();
-            conn.setReadTimeout(5000);
-            conn.setConnectTimeout(1000);
-            ((HttpURLConnection) conn).setRequestMethod("PUT");
-            ((HttpURLConnection) conn).setRequestProperty("Authorization", "Token " + token);
-            conn.connect();
-            int statusCode = ((HttpURLConnection) conn).getResponseCode();
-            if (statusCode != HttpURLConnection.HTTP_CREATED) {
-                throw new JobExecutionException("HttpRequest not success:" + statusCode);
-            }
-        } catch (IOException ex) {
-            throw new JobExecutionException(ex);
+        IFn executionResource = Clojure.var("job-streamer.control-bus.component.jobs", "execution-resource");
+        IFn handler = (IFn) executionResource.invoke(jobs, executionId, Keyword.intern(command));
+        PersistentHashMap request = PersistentHashMap.create(
+                Keyword.intern("request-method"), Keyword.intern("put"),
+                Keyword.intern("identity"), PersistentHashMap.create(
+                    Keyword.intern("permissions"), PersistentHashSet.create(
+                        Keyword.intern("permission", "execute-job"))),
+                Keyword.intern("content-type"), "application/edn");
+        long statusCode = (long) RT.get(handler.invoke(request), Keyword.intern("status"));
+        if (statusCode != (long) HttpURLConnection.HTTP_CREATED) {
+            throw new JobExecutionException("HttpRequest not success:" + statusCode);
         }
-
-
     }
 }

--- a/src/java/net/unit8/job_streamer/control_bus/util/SystemUtil.java
+++ b/src/java/net/unit8/job_streamer/control_bus/util/SystemUtil.java
@@ -7,7 +7,7 @@ import clojure.lang.*;
  */
 public class SystemUtil {
     public static Object getSystem() {
-        Var varSystem = RT.var("job-streamer.agent.main", "system");
+        Var varSystem = RT.var("job-streamer.control-bus.main", "system");
         if (varSystem.isBound()) {
             Atom mainSystemAtom = (Atom) varSystem.get();
             Object system = mainSystemAtom.deref();

--- a/src/java/net/unit8/job_streamer/control_bus/util/SystemUtil.java
+++ b/src/java/net/unit8/job_streamer/control_bus/util/SystemUtil.java
@@ -1,0 +1,23 @@
+package net.unit8.job_streamer.control_bus.util;
+
+import clojure.lang.*;
+
+/**
+ * @author Yuki Seki
+ */
+public class SystemUtil {
+    public static Object getSystem() {
+        Var varSystem = RT.var("job-streamer.agent.main", "system");
+        if (varSystem.isBound()) {
+            Atom mainSystemAtom = (Atom) varSystem.get();
+            Object system = mainSystemAtom.deref();
+            if (system != null) {
+                return system;
+            }
+        }
+
+        // Fallback... System must be started in REPL.
+        return RT.var("reloaded.repl", "system").get();
+    }
+}
+

--- a/test/clj/job_streamer/control_bus/component/jobs_test.clj
+++ b/test/clj/job_streamer/control_bus/component/jobs_test.clj
@@ -3,8 +3,7 @@
                                                 [apps :as apps]
                                                 [scheduler :as scheduler]
                                                 [datomic :refer [datomic-component] :as d]
-                                                [migration :refer [migration-component]]
-                                                [token :refer [token-provider-component]])
+                                                [migration :refer [migration-component]])
             (job-streamer.control-bus [system :as system]
                                       [model :as model]
                                       [config :as config])
@@ -33,12 +32,11 @@
        :jobs    (jobs/jobs-component (:jobs config))
        :scheduler (scheduler/scheduler-component (:scheduler config))
        :datomic (datomic-component   (:datomic config))
-       :migration (migration-component {:dbschema model/dbschema})
-       :token (token-provider-component {:token config}))
+       :migration (migration-component {:dbschema model/dbschema}))
       (component/system-using
        {:jobs [:datomic :migration :scheduler]
         :apps [:datomic]
-        :scheduler [:datomic :token]
+        :scheduler [:datomic]
         :migration [:datomic]})
       (component/start-system)))
 


### PR DESCRIPTION
# Problem
Scheduler failed to execute job after a certain period of time.

# Cause
Scheduler issued an authentication token when it was created. Then the authentication token was cleaned by ttl after a certain period of time. When scheduler executed the job via self HTTP endpoint with authentication token, there were no authentication related to the token. So the execution failed.

# Fixture
I changed scheduler job classes to call job handler directly not via HTTP. So authentication token is no longer needed by scheduler.