### PR TITLE
Changed BatchComponentScanner to catch Throwables when it loads clazzes in batch jar.

### DIFF
--- a/src/clj/job_streamer/control_bus/component/apps.clj
+++ b/src/clj/job_streamer/control_bus/component/apps.clj
@@ -54,7 +54,7 @@
         (letfn [(print-err []
                       (with-open [rdr (io/reader (.getErrorStream proc))]
                         (->> (line-seq rdr)
-                             (map #(log/error %))
+                             (map #(log/debug %))
                              doall)))]
           (.start (Thread. print-err)))
         (with-open [rdr (io/reader (.getInputStream proc))]

--- a/src/java/net/unit8/job_streamer/control_bus/BatchComponentScanner.java
+++ b/src/java/net/unit8/job_streamer/control_bus/BatchComponentScanner.java
@@ -67,8 +67,8 @@ public class BatchComponentScanner {
     }
 
     String decideRefName(Class<?> clazz) {
-        System.err.println(clazz);
-        System.err.println(clazz.getAnnotations());
+        System.err.println("decideRefName: clazz: " + clazz);
+        System.err.println("decideRefName: annotation: " + clazz.getAnnotations());
         Annotation[] annotations = clazz.getDeclaredAnnotations();
         for (Annotation annotation : annotations) {
             if (annotation instanceof Named && !Strings.isNullOrEmpty(((Named) annotation).value())) {
@@ -83,29 +83,41 @@ public class BatchComponentScanner {
             String className = resourcePath
                     .substring(0, resourcePath.lastIndexOf(".class"))
                     .replace('/', '.').replace('\\', '.');
+            System.err.println("className: " + className);
             if (className.startsWith("java.")
                     || className.startsWith("javax.")
                     || className.startsWith("com.sun.")
                     || className.startsWith("sun.")
                     || className.startsWith("clojure.")) {
+                System.err.println("This is ignored with wrong package name");
                 return;
             }
             try {
                 Class<?> clazz = cl.loadClass(className);
                 if (Batchlet.class.isAssignableFrom(clazz)) {
-                    container.batchlets.add(decideRefName(clazz));
+                  System.err.println("  This clazz is Batchlet");
+                  container.batchlets.add(decideRefName(clazz));
                 } else if (ItemReader.class.isAssignableFrom(clazz)) {
-                    container.itemReaders.add(decideRefName(clazz));
+                  System.err.println("  This clazz is ItemReader");
+                  container.itemReaders.add(decideRefName(clazz));
                 } else if (ItemWriter.class.isAssignableFrom(clazz)) {
-                    container.itemWriters.add(decideRefName(clazz));
+                  System.err.println("  This clazz is ItemWriter");
+                  container.itemWriters.add(decideRefName(clazz));
                 } else if (ItemProcessor.class.isAssignableFrom(clazz)) {
-                    container.itemProcessors.add(decideRefName(clazz));
+                  System.err.println("  This clazz is ItemProcessor");
+                  container.itemProcessors.add(decideRefName(clazz));
                 } else if (isListener(clazz)) {
-                    container.listeners.add(decideRefName(clazz));
+                  System.err.println("  This clazz is Listener");
+                  container.listeners.add(decideRefName(clazz));
                 } else if (Throwable.class.isAssignableFrom(clazz)) {
-                    container.throwables.add(decideRefName(clazz));
+                  System.err.println("  This clazz is Throwable");
+                  container.throwables.add(decideRefName(clazz));
+                } else {
+                  System.err.println("  This clazz is ignored");
                 }
             } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                System.err.println("  This clazz is ignored with Exception");
+                e.printStackTrace();
                 // ignore
             }
         }

--- a/src/java/net/unit8/job_streamer/control_bus/BatchComponentScanner.java
+++ b/src/java/net/unit8/job_streamer/control_bus/BatchComponentScanner.java
@@ -89,36 +89,35 @@ public class BatchComponentScanner {
                     || className.startsWith("com.sun.")
                     || className.startsWith("sun.")
                     || className.startsWith("clojure.")) {
-                System.err.println("This is ignored with wrong package name");
+                System.err.println("This is ignored according to package name.");
                 return;
             }
             try {
                 Class<?> clazz = cl.loadClass(className);
                 if (Batchlet.class.isAssignableFrom(clazz)) {
-                  System.err.println("  This clazz is Batchlet");
+                  System.err.println("  This clazz is Batchlet.");
                   container.batchlets.add(decideRefName(clazz));
                 } else if (ItemReader.class.isAssignableFrom(clazz)) {
-                  System.err.println("  This clazz is ItemReader");
+                  System.err.println("  This clazz is ItemReader.");
                   container.itemReaders.add(decideRefName(clazz));
                 } else if (ItemWriter.class.isAssignableFrom(clazz)) {
-                  System.err.println("  This clazz is ItemWriter");
+                  System.err.println("  This clazz is ItemWriter.");
                   container.itemWriters.add(decideRefName(clazz));
                 } else if (ItemProcessor.class.isAssignableFrom(clazz)) {
-                  System.err.println("  This clazz is ItemProcessor");
+                  System.err.println("  This clazz is ItemProcessor.");
                   container.itemProcessors.add(decideRefName(clazz));
                 } else if (isListener(clazz)) {
-                  System.err.println("  This clazz is Listener");
+                  System.err.println("  This clazz is Listener.");
                   container.listeners.add(decideRefName(clazz));
                 } else if (Throwable.class.isAssignableFrom(clazz)) {
-                  System.err.println("  This clazz is Throwable");
+                  System.err.println("  This clazz is Throwable.");
                   container.throwables.add(decideRefName(clazz));
                 } else {
-                  System.err.println("  This clazz is ignored");
+                  System.err.println("  This clazz is ignored.");
                 }
-            } catch (ClassNotFoundException | NoClassDefFoundError e) {
-                System.err.println("  This clazz is ignored with Exception");
+            } catch (Throwable e) {
+                System.err.println("  This clazz is ignored with Throwable.");
                 e.printStackTrace();
-                // ignore
             }
         }
     }


### PR DESCRIPTION
There are cases where job-streamer can not load batch components in batch jar file.
This happens when BatchComponentScanner does not catch Throwables(Exception/Error) with loading clazzes.
So I changed BatchComponentScanner to catch Throwables and log them when BatchComponentScanner  loads clazzes in batch jar.